### PR TITLE
First commit for spinner component with fixed size

### DIFF
--- a/front-end/src/components/Spinner.jsx
+++ b/front-end/src/components/Spinner.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import clsx from 'clsx';
 import { makeStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
@@ -10,9 +11,11 @@ const useStyles = makeStyles(() => ({
     height: '120px',
   },
 }));
-const Spinner = () => {
+const Spinner = ({ className }) => {
   const classes = useStyles();
-  return <CircularProgress disableShrink className={classes.spinner} />;
+  return (
+    <CircularProgress disableShrink className={clsx(classes.root, className)} />
+  );
 };
 
 export default Spinner;

--- a/front-end/src/components/Spinner.jsx
+++ b/front-end/src/components/Spinner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const useStyles = makeStyles(() => ({
+  spinner: {
+    margin: 'auto',
+    display: 'block',
+    width: '120px',
+    height: '120px',
+  },
+}));
+const Spinner = () => {
+  const classes = useStyles();
+  return <CircularProgress disableShrink className={classes.spinner} />;
+};
+
+export default Spinner;


### PR DESCRIPTION
This is an initial commit for loading icon or spinning icon as we know. It will be used when data is being fetched or page is being loaded. Style will be added more for responsive design once the designer gives a mock up for the spinner/loading icon in material UI 